### PR TITLE
delete form from menu until I solve formspree issue

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -90,8 +90,3 @@ footnoteReturnLinkContents = "↩" # Provides a nicer footnote return link
   weight = 3
   identifier = "info"
   url = "/page/info/"
-[[menu.main]]
-  name = "Contacto"
-  weight = 4
-  identifier = "contact"
-  url = "/contact/form/"


### PR DESCRIPTION
I have this issue when trying to implement Formspree:

**Unable to submit form
Make sure you open this page through a web server, Formspree will not work in pages browsed as HTML files. Also make sure that you're posting to https://formspree.io/martinezmiro@gmail.com.

For geeks: could not find the "Referrer" header.**

So I will delete the menu from config.toml until I try to solve this issue